### PR TITLE
fix(dedx/chain): count update-frequency gates per BATCH, not per global iteration

### DIFF
--- a/optimize/fit_params.py
+++ b/optimize/fit_params.py
@@ -2376,6 +2376,30 @@ class GradientDescentFitter(ParamFitter):
             self._chain_cache[batch_idx] = states
         return self._chain_cache[batch_idx]
 
+    def _freq_gate(self, tag, batch_idx, freq):
+        """Every-`freq`-VISITS gate, counted PER BATCH.
+
+        Replaces `total_iter % freq == 0`, which is a global-iteration gate and is broken under
+        sequential batching: batch b is always visited at total_iter == b (mod nbatch), so
+        `total_iter % freq == 0` is a FIXED function of the batch index. With freq > 1 a fixed
+        subset of batches receives EVERY update and the rest receive NONE, ever. Measured at
+        nbatch=100: freq=2 -> 50/100 batches never update, freq=4 -> 75/100, freq=5 -> 80/100,
+        freq=10 -> 90/100. Shuffling the batch order accidentally repairs it, which also makes the
+        two orderings incomparable. Counting each batch's own visits makes the gate mean what it
+        says and removes the order dependence.
+
+        freq <= 1 fires on every visit, identical to the old behaviour (which was already correct
+        at freq == 1, the default -- so no existing run changes).
+        """
+        if freq is None or freq <= 1:
+            return True
+        if not hasattr(self, '_freq_counters'):
+            self._freq_counters = {}
+        key = (tag, int(batch_idx))
+        n = self._freq_counters.get(key, 0)
+        self._freq_counters[key] = n + 1
+        return n % int(freq) == 0
+
     def _chain_lr_scale(self, total_iter):
         """Exponential decay factor for the chain-position learning rate.
 
@@ -3497,7 +3521,7 @@ class GradientDescentFitter(ParamFitter):
                                          or total_iter < self.dedx_start_iter))
                     _chain_active = (_chain_available and
                                      total_iter >= self._chain_start_iter and
-                                     total_iter % self._chain_update_freq == 0)
+                                     self._freq_gate('chain', i, self._chain_update_freq))
                     _chain_frozen_now = (self._chain_freeze_iter > 0 and total_iter >= self._chain_freeze_iter)
                     if _chain_available:
                         _chain_states   = self._get_or_init_chain_state(i)
@@ -3554,10 +3578,17 @@ class GradientDescentFitter(ParamFitter):
                                     max_iter=self._geom_lbfgs_steps)
                         else:
                             self._process_chain_grads(i, _grads_chain, total_iter)
-                        if total_iter % self._pos_residual_freq == 0:
+                        if self._freq_gate('posres', i, self._pos_residual_freq):
                             _pos_res = self._compute_pos_residual_batch(i)
                             if _pos_res is not None:
                                 self.training_history.setdefault('pos_residual_iter', []).append(_pos_res)
+                                # Record WHICH batch this residual belongs to. pos_residual is a
+                                # per-batch quantity and batches differ enormously (individual
+                                # batches span 62-3051 um around an 881 um median), so a bare time
+                                # series is only interpretable if the visit order is known. Without
+                                # this a --shuffle_bt run cannot be compared against a sequential
+                                # one at all. Additive; one int per recorded residual.
+                                self.training_history.setdefault('pos_residual_batch', []).append(int(i))
                         # env-gated: snapshot this batch's chain angles for oscillation viz
                         if os.environ.get('LARND_SNAPSHOT'):
                             self.training_history.setdefault('chain_snapshots', []).append(
@@ -3773,6 +3804,18 @@ class LikelihoodProfiler(ParamFitter):
             for param in self.relevant_params_list:
                 lower = ranges[param]['down']
                 upper = ranges[param]['up']
+                # LARND_SCAN_WINDOW (default unset = full ranges.py interval, bit-identical to
+                # before) narrows the grid to nom*(1 +/- w) so the SAME number of steps resolves
+                # the minimum far better. Needed because the full-range grid is much coarser than
+                # the likelihood width (the lifetime step is 10.2% of truth against a 0.88% Fisher
+                # sigma), so the parabola vertex is an extrapolation and shifts ~2.4 points between
+                # a 3- and a 5-point fit. Cost is steps x batches and does NOT depend on the span,
+                # so resolution is free.
+                _w = float(os.environ.get('LARND_SCAN_WINDOW', 0) or 0)
+                if _w > 0:
+                    nom = ranges[param]['nom']
+                    lower = max(nom * (1.0 - _w), ranges[param]['down'])
+                    upper = min(nom * (1.0 + _w), ranges[param]['up'])
                 param_step = (upper - lower)/(nb_steps - 1)
 
                 for iter in tqdm(range(nb_steps)):

--- a/optimize/scripts/make_quality_ladder.py
+++ b/optimize/scripts/make_quality_ladder.py
@@ -1,0 +1,161 @@
+"""Build controlled degradations of the TRUE segment file, for the likelihood-scan
+quality studies.
+
+We cannot interpolate between the true file and linear_guess_segments.h5: they have different
+segmentations (3.03M vs 10.08M segments), so there is no row correspondence. Instead we perturb
+the true file itself, which keeps everything except the axis under study identical.
+
+POSITION ladder (--mode pos --rms <um>): each TRAJECTORY is displaced by a single random 3-D
+offset with the requested RMS magnitude. A whole-trajectory rigid shift (rather than per-segment
+jitter) is the right model here because the spline geometry basis represents smooth per-track
+displacement, and it is what the fitted geometry residual (~168 um) actually measures.
+
+DEDX ladder (--mode dedx --frac f): dEdx is blended toward the global mean,
+    dEdx' = mean + f*(dEdx - mean)
+so f=1 is the truth and f=0 is constant-at-the-mean (the CONSTDEDX condition). dE is rescaled
+consistently (dE = dEdx*dx) and n_electrons is scaled by the same ratio, since the number of
+ionisation electrons is proportional to the deposited energy.
+
+CHORD ladder (--mode chord --chord c): each trajectory is pulled toward the straight line joining
+its first and last point, by fraction c (0 = truth, 1 = perfectly straight). This is a SYSTEMATIC,
+along-track-correlated geometry error -- the kind the straight-line guess file actually has --
+as opposed to the `pos` mode's random rigid offsets, which are uncorrelated between trajectories
+and preserve each track's shape. The `pos` ladder showed random offsets cost variance but not
+bias, while the guess file is badly biased, so the error STRUCTURE is the remaining suspect.
+dEdx is held fixed and dE/n_electrons are rescaled to the new (shorter) dx, so this is a pure
+geometry change and does not leak into the dEdx axis.
+"""
+import argparse, os
+import numpy as np
+import h5py
+
+TRUE = '/sdf/data/neutrino/cyifan/diffsim_input/true_through_muon_edep_10cm_vol1cm.h5'
+POSF = [('x', 'y', 'z'), ('x_start', 'y_start', 'z_start'), ('x_end', 'y_end', 'z_end')]
+
+ap = argparse.ArgumentParser()
+ap.add_argument('--mode', choices=['pos', 'dedx', 'chord'], required=True)
+ap.add_argument('--rms', type=float, default=0.0, help='position RMS in micrometres')
+ap.add_argument('--frac', type=float, default=1.0, help='dEdx retention fraction (1=truth, 0=mean)')
+ap.add_argument('--chord', type=float, default=1.0, help='straightening fraction (0=truth, 1=straight)')
+ap.add_argument('--post_frac', type=float, default=1.0,
+                help='dEdx spread blend applied AFTER the geometry mode (composes with pos/chord)')
+ap.add_argument('--mean_shift', type=float, default=0.0,
+                help='multiplicative dEdx mean shift, e.g. 0.02 = +2%%; spread shape preserved')
+ap.add_argument('--out', required=True)
+ap.add_argument('--seed', type=int, default=12345)
+a = ap.parse_args()
+
+with h5py.File(TRUE, 'r') as f:
+    seg = f['segments'][:]
+    traj = f['trajectories'][:]
+
+if a.mode == 'pos':
+    rms_cm = a.rms * 1e-4                       # micrometres -> cm
+    # one rigid offset per (event_id, traj_id); sigma per axis so that |offset| has the target RMS
+    key = seg['event_id'].astype(np.int64) * 1000000 + seg['traj_id'].astype(np.int64)
+    uniq, inv = np.unique(key, return_inverse=True)
+    rng = np.random.default_rng(a.seed)
+    off = rng.normal(0.0, rms_cm / np.sqrt(3.0), size=(len(uniq), 3))
+    got = np.sqrt((off ** 2).sum(1).mean()) * 1e4
+    print(f'[pos] {len(uniq)} trajectories, requested RMS {a.rms:.1f} um, realised {got:.1f} um')
+    for trip in POSF:
+        for j, fld in enumerate(trip):
+            if fld in seg.dtype.names:
+                seg[fld] = seg[fld] + off[inv, j]
+elif a.mode == 'chord':
+    c = a.chord
+    key = seg['event_id'].astype(np.int64) * 1000000 + seg['traj_id'].astype(np.int64)
+    # order segments along each track so "first start" and "last end" are the track's endpoints
+    order = np.lexsort((seg['segment_id'], key))
+    ks = key[order]
+    grp_start = np.flatnonzero(np.r_[True, ks[1:] != ks[:-1]])
+    grp_end = np.r_[grp_start[1:] - 1, len(ks) - 1]
+    gid = np.zeros(len(ks), np.int64)
+    gid[grp_start[1:]] = 1
+    gid = np.cumsum(gid)                                   # group index per (sorted) row
+
+    P0 = np.stack([seg[f][order][grp_start].astype(np.float64) for f in ('x_start', 'y_start', 'z_start')], 1)
+    P1 = np.stack([seg[f][order][grp_end].astype(np.float64) for f in ('x_end', 'y_end', 'z_end')], 1)
+    D = P1 - P0
+    L = np.linalg.norm(D, axis=1)
+    u = D / np.where(L[:, None] > 0, L[:, None], 1.0)      # unit chord direction per track
+    print(f'[chord] {len(P0)} trajectories, straightening fraction c={c}')
+
+    dev = []
+    for trip in POSF:
+        if not all(f in seg.dtype.names for f in trip):
+            continue
+        p = np.stack([seg[f][order].astype(np.float64) for f in trip], 1)
+        rel = p - P0[gid]
+        proj = P0[gid] + (np.einsum('ij,ij->i', rel, u[gid])[:, None]) * u[gid]
+        dev.append(np.linalg.norm(p - proj, axis=1))
+        newp = p + c * (proj - p)                          # pull toward the chord
+        for j, fld in enumerate(trip):
+            out = seg[fld].copy()
+            out[order] = newp[:, j].astype(seg[fld].dtype)
+            seg[fld] = out
+    print(f'[chord] transverse deviation from the chord, before: mean {np.mean(dev[0]) * 1e4:.0f} um, '
+          f'95th pct {np.percentile(dev[0], 95) * 1e4:.0f} um  -> after: x{1 - c:.2f}')
+
+    # dEdx is the physics we are NOT changing: recompute dx from the new endpoints and rescale
+    # the extensive quantities so dEdx stays exactly as it was.
+    ns = np.stack([seg[f].astype(np.float64) for f in ('x_start', 'y_start', 'z_start')], 1)
+    ne = np.stack([seg[f].astype(np.float64) for f in ('x_end', 'y_end', 'z_end')], 1)
+    new_dx = np.linalg.norm(ne - ns, axis=1)
+    old_dx = seg['dx'].astype(np.float64)
+    ratio = np.where(old_dx > 0, new_dx / np.where(old_dx > 0, old_dx, 1.0), 1.0)
+    seg['dx'] = new_dx.astype(seg['dx'].dtype)
+    for fld in ('dE', 'n_electrons', 'n_photons'):
+        if fld in seg.dtype.names:
+            seg[fld] = (seg[fld].astype(np.float64) * ratio).astype(seg[fld].dtype)
+    print(f'[chord] dx mean {old_dx.mean():.4f} -> {new_dx.mean():.4f} '
+          f'(total track length x{new_dx.sum() / old_dx.sum():.4f}); dEdx unchanged by construction')
+else:
+    dedx = seg['dEdx'].astype(np.float64)
+    dx = seg['dx'].astype(np.float64)
+    m = dedx.mean()
+    new = m + a.frac * (dedx - m)
+    ratio = np.where(dedx > 0, new / np.where(dedx > 0, dedx, 1.0), 1.0)
+    seg['dEdx'] = new.astype(seg['dEdx'].dtype)
+    if 'dE' in seg.dtype.names:
+        seg['dE'] = (new * dx).astype(seg['dE'].dtype)
+    if 'n_electrons' in seg.dtype.names:
+        seg['n_electrons'] = (seg['n_electrons'].astype(np.float64) * ratio).astype(seg['n_electrons'].dtype)
+    print(f'[dedx] frac={a.frac}  mean={m:.5f}  spread {dedx.std():.5f} -> {new.std():.5f}')
+
+# ---------------------------------------------------------------- composable dE/dx post-transforms
+# These run AFTER the geometry mode, so a single file can carry BOTH a geometry defect and a dE/dx
+# defect -- which is what the straight-line guess file actually has, and what no single-axis rung
+# has ever tested. Applied to whatever `seg` the mode above produced.
+if a.post_frac != 1.0:
+    dedx = seg['dEdx'].astype(np.float64)
+    m = dedx.mean()
+    new = m + a.post_frac * (dedx - m)
+    ratio = np.where(dedx > 0, new / np.where(dedx > 0, dedx, 1.0), 1.0)
+    seg['dEdx'] = new.astype(seg['dEdx'].dtype)
+    if 'dE' in seg.dtype.names:
+        seg['dE'] = (new * seg['dx'].astype(np.float64)).astype(seg['dE'].dtype)
+    if 'n_electrons' in seg.dtype.names:
+        seg['n_electrons'] = (seg['n_electrons'].astype(np.float64) * ratio).astype(seg['n_electrons'].dtype)
+    print(f'[post-dedx] frac={a.post_frac}  spread {dedx.std():.5f} -> {new.std():.5f}')
+
+# MEAN SHIFT: dEdx -> dEdx*(1+s), i.e. the whole distribution scaled, spread SHAPE preserved.
+# This is the error an over-stiff dEdx mean constraint imposes: the fitted mean is pinned by the
+# prior (target 1.887 at w=1e5) rather than determined by the data, so if the data's true mean
+# differs, every segment carries a common multiplicative offset. The `dedx` ladder shrinks the
+# SPREAD and leaves the mean alone; this is the orthogonal axis and had never been measured.
+if a.mean_shift != 0.0:
+    dedx = seg['dEdx'].astype(np.float64)
+    new = dedx * (1.0 + a.mean_shift)
+    seg['dEdx'] = new.astype(seg['dEdx'].dtype)
+    if 'dE' in seg.dtype.names:
+        seg['dE'] = (new * seg['dx'].astype(np.float64)).astype(seg['dE'].dtype)
+    if 'n_electrons' in seg.dtype.names:
+        seg['n_electrons'] = (seg['n_electrons'].astype(np.float64) * (1.0 + a.mean_shift)).astype(seg['n_electrons'].dtype)
+    print(f'[mean-shift] {a.mean_shift:+.4f}  mean {dedx.mean():.5f} -> {new.mean():.5f}')
+
+os.makedirs(os.path.dirname(a.out), exist_ok=True)
+with h5py.File(a.out, 'w') as f:
+    f.create_dataset('segments', data=seg)
+    f.create_dataset('trajectories', data=traj)
+print('wrote', a.out, os.path.getsize(a.out) / 1e9, 'GB')

--- a/optimize/scripts/make_resegmented.py
+++ b/optimize/scripts/make_resegmented.py
@@ -1,0 +1,92 @@
+"""Re-segment the TRUE file to the guess file's segmentation, changing NOTHING else.
+
+WHY. The straight-line guess file displaces the likelihood minimum further than either axis of
+the quality ladder: lifetime +15.2%, where destroying all dE/dx information gives +7.0% and
+880 um of position error gives -3.8%. Neither axis, nor their sum, accounts for it (report S6f,
+open question 11). The remaining structural difference between the two files is segmentation:
+
+    TRUE   3 030 787 segments, dx variable, mean 3.28 cm, median 2.28 cm
+    GUESS 10 079 953 segments, dx uniform  ~0.99 cm
+
+i.e. the guess file is resegmented onto a uniform ~1 cm step. Since the per-segment dE/dx prior
+(student-t + soft barrier + mean constraint) is tuned on the TRUE dx distribution, applying it to
+3.3x shorter segments is a real, untested change of conditions.
+
+WHAT THIS BUILDS. Each true segment is split into N = max(1, round(dx/1cm)) collinear pieces.
+Endpoints are linearly interpolated along the segment, so every sub-segment lies exactly on the
+original track: positions are UNCHANGED as a curve. dE/dx, and the diffusion coefficients are
+copied verbatim; the extensive quantities (dx, dE, n_electrons, n_photons) are divided by N, so
+the total deposited energy and electron count are conserved exactly.
+
+The result therefore differs from the TRUE file in segmentation ALONE -- not position, not dE/dx,
+not charge. Scanning it isolates the effect that neither ladder axis captures.
+"""
+import argparse
+import numpy as np
+import h5py
+
+TRUE = '/sdf/data/neutrino/cyifan/diffsim_input/true_through_muon_edep_10cm_vol1cm.h5'
+# linearly interpolated along the segment: (start field, end field, midpoint field or None)
+GEOM = [('x_start', 'x_end', 'x'), ('y_start', 'y_end', 'y'), ('z_start', 'z_end', 'z'),
+        ('t_start', 't_end', 't'), ('t0_start', 't0_end', 't0')]
+EXTENSIVE = ['dx', 'dE', 'n_electrons', 'n_photons']
+
+ap = argparse.ArgumentParser()
+ap.add_argument('--target_dx', type=float, default=0.99, help='sub-segment length in cm')
+ap.add_argument('--out', required=True)
+a = ap.parse_args()
+
+with h5py.File(TRUE, 'r') as f:
+    seg = f['segments'][:]
+    traj = f['trajectories'][:]
+
+dx = seg['dx'].astype(np.float64)
+n = np.maximum(1, np.rint(np.abs(dx) / a.target_dx)).astype(np.int64)
+tot = int(n.sum())
+print(f'{len(seg)} segments -> {tot} ({tot / len(seg):.2f}x), target dx {a.target_dx} cm')
+
+src = np.repeat(np.arange(len(seg)), n)              # parent index of each sub-segment
+# k = 0..n-1 within each parent, via the standard repeat-offset trick
+starts = np.repeat(np.cumsum(n) - n, n)
+k = np.arange(tot) - starts
+nn = n[src].astype(np.float64)
+
+out = np.zeros(tot, dtype=seg.dtype)
+for fld in seg.dtype.names:                          # default: copy from the parent
+    out[fld] = seg[fld][src]
+
+for s, e, mid in GEOM:
+    if s not in seg.dtype.names:
+        continue
+    p0 = seg[s][src].astype(np.float64)
+    p1 = seg[e][src].astype(np.float64)
+    f0, f1 = k / nn, (k + 1.0) / nn
+    ns, ne = p0 + (p1 - p0) * f0, p0 + (p1 - p0) * f1
+    out[s] = ns.astype(seg[s].dtype)
+    out[e] = ne.astype(seg[e].dtype)
+    if mid and mid in seg.dtype.names:
+        out[mid] = (0.5 * (ns + ne)).astype(seg[mid].dtype)
+
+for fld in EXTENSIVE:
+    if fld in seg.dtype.names:
+        out[fld] = (seg[fld][src].astype(np.float64) / nn).astype(seg[fld].dtype)
+
+if 'segment_id' in seg.dtype.names:
+    out['segment_id'] = np.arange(tot).astype(seg['segment_id'].dtype)
+
+# conservation / invariance checks -- these are the point of the file, so assert them loudly
+for fld in ['dE', 'n_electrons', 'dx']:
+    if fld in seg.dtype.names:
+        o, i = out[fld].astype(np.float64).sum(), seg[fld].astype(np.float64).sum()
+        print(f'  {fld:12s} total {i:.6g} -> {o:.6g}   ({100 * (o / i - 1):+.4f}%)')
+d_in = seg['dEdx'].astype(np.float64)
+d_out = out['dEdx'].astype(np.float64)
+print(f'  dEdx         mean {d_in.mean():.5f} -> {d_out.mean():.5f}, '
+      f'sd {d_in.std():.5f} -> {d_out.std():.5f}')
+print(f'  dx           mean {dx.mean():.4f} -> {out["dx"].astype(np.float64).mean():.4f}')
+
+with h5py.File(a.out, 'w') as f:
+    f.create_dataset('segments', data=out)
+    f.create_dataset('trajectories', data=traj)
+import os
+print('wrote', a.out, os.path.getsize(a.out) / 1e9, 'GB')

--- a/optimize/scripts/start_batchceiling.sh
+++ b/optimize/scripts/start_batchceiling.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+#SBATCH --partition=ampere
+#SBATCH --account=neutrino:cider-nu
+#SBATCH --job-name=batchceil
+#SBATCH --output=/sdf/group/neutrino/pgranger/larnd-sim-jax/logs/batchceiling/job-%A.out
+#SBATCH --ntasks=1 --cpus-per-task=2 --mem-per-cpu=32g
+#SBATCH --gpus-per-node=a100:1 --time=06:00:00
+#
+# DIRECT batch-size ceiling test on the PRODUCTION configuration.
+#
+# WHY: the existing scaling law (peak_MiB = 3471 + 70.1*cm/batch) was fitted on the GN path with an
+# exact Hessian, on an 11 GiB turing card. Production is Adam + dEdx + chain geometry on an A100,
+# and measures 23.4 GiB at 400 cm/batch where that law predicts ~30.8 -- so the law is conservative
+# and the real ceiling is unknown. This measures it instead of extrapolating.
+#
+# ALSO: production sets no allocator env, so JAX preallocates its DEFAULT 75% of the card. That is
+# why every run reports bytes_limit = 29.55 GiB on a 40 GB A100 -- ~10 GiB is simply never offered
+# to the process. MEMFRAC=0.95 tests how much of that is recoverable for free.
+#
+# Each LEN runs in its OWN python process so an OOM kills only that point, not the sweep.
+# Peak memory is sampled from nvidia-smi, which works regardless of allocator (jax's memory_stats
+# returns nothing under the platform allocator -- that is the "peak_mem 0.00 GiB" trap).
+set -u
+LENS=${LENS:-"400 600 800 1000 1200"}
+NB=${CEILNB:-25}
+ITERS=${CEILITERS:-25}
+MEMFRAC=${MEMFRAC:-}
+SIM=/sdf/group/neutrino/pgranger/lads-data/linear_guess_segments.h5
+TGT=/sdf/data/neutrino/cyifan/diffsim_input/true_through_muon_edep_10cm_vol1cm.h5
+mkdir -p /sdf/group/neutrino/pgranger/larnd-sim-jax/logs/batchceiling
+
+echo "=== batch-size ceiling sweep: LENS='${LENS}' NB=${NB} ITERS=${ITERS} MEMFRAC='${MEMFRAC:-default(0.75)}' ==="
+nvidia-smi --query-gpu=name,memory.total --format=csv,noheader
+
+for LEN in ${LENS}; do
+  MEMLOG=/tmp/ceil_mem_${SLURM_JOB_ID:-$$}_${LEN}.txt
+  ( while true; do nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits; sleep 2; done \
+      > "$MEMLOG" 2>/dev/null ) &
+  SAMPLER=$!
+  RUNLOG=/tmp/ceil_run_${SLURM_JOB_ID:-$$}_${LEN}.log
+
+  apptainer exec --nv -B /sdf,/fs,/lscratch larndsim-jax_main.sif /bin/bash -c "
+    cd /sdf/group/neutrino/pgranger/larnd-sim-jax
+    export PYTHONPATH=\$PWD/src:\$PWD:\$PYTHONPATH
+    export JAX_COMPILATION_CACHE_DIR=/sdf/group/neutrino/pgranger/.jax_cache
+    ${MEMFRAC:+export XLA_PYTHON_CLIENT_MEM_FRACTION=${MEMFRAC}}
+    python3 -m optimize.example_run \
+      --params optimize/scripts/param_list_nd_noshift.yaml \
+      --input_file_sim ${SIM} --input_file_tgt ${TGT} \
+      --fit_type chain --iterations ${ITERS} --max_nbatch ${NB} --max_batch_len ${LEN} \
+      --data_seed 1 --seed 0 \
+      --lr 1e-1 --optimizer_fn Adam --lr_scheduler exponential_decay \
+      --lr_kw '{\"decay_rate\":0.91,\"init_value\":0,\"warmup_steps\":500}' \
+      --max_clip_norm_val 1 --electron_sampling_resolution 0.005 --number_pix_neighbors 4 \
+      --signal_length 150 --mode lut --lut_file src/larndsim/detector_properties/response_44.npy \
+      --loss_fn llhd --probabilistic_sim --sim_seed_strategy same --non_deterministic \
+      --fit_dedx --dedx_prior_weight 5 --dedx_mean_constraint_weight 1e5 \
+      --fit_chain_positions --chain_basis spline --chain_lr 1e-2 --chain_decay_rate 0.999 \
+      --mcs_prior_weight 0.5 \
+      --out_label ceil_len${LEN} --test_name batchceiling --save_freq 1000000
+  " > "$RUNLOG" 2>&1
+  STATUS=$?
+  kill $SAMPLER 2>/dev/null || true
+
+  PEAK=$(sort -n "$MEMLOG" 2>/dev/null | tail -1)
+  # realised geometry: batches pack whole EVENTS, so actual cm/batch can differ from LEN, and
+  # dataio DISCARDS trajectories longer than max_batch_len -- both make LEN a request, not a fact.
+  CM=$(grep -m1 "total track length" "$RUNLOG" | grep -oE "[0-9.]+" | head -1)
+  NBATCH=$(grep -m1 "number of simulation batches" "$RUNLOG" | grep -oE "[0-9]+" | tail -1)
+  OOM=""
+  grep -qiE "RESOURCE_EXHAUSTED|out of memory|OOM|XlaRuntimeError" "$RUNLOG" && OOM="OOM"
+  ITDONE=$(grep -oE "[0-9]+/${ITERS}" "$RUNLOG" | tail -1)
+  echo "[CEIL] LEN=${LEN} status=${STATUS} ${OOM:-ok} peak=${PEAK:-?} MiB total_cm=${CM:-?} nbatch=${NBATCH:-?} progress=${ITDONE:-none}"
+  if [ -n "$CM" ] && [ -n "$NBATCH" ] && [ "$NBATCH" -gt 0 ] 2>/dev/null; then
+    echo "[CEIL]   -> realised $(python3 -c "print(f'{${CM}/${NBATCH}:.1f}')") cm/batch"
+  fi
+  [ -n "$OOM" ] && echo "[CEIL]   first OOM line: $(grep -m1 -iE 'RESOURCE_EXHAUSTED|out of memory' "$RUNLOG" | cut -c1-160)"
+  rm -f "$MEMLOG"
+done
+echo "=== sweep done ==="

--- a/optimize/scripts/start_hitdump.sh
+++ b/optimize/scripts/start_hitdump.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#SBATCH --partition=ampere
+#SBATCH --account=neutrino:cider-nu
+#SBATCH --job-name=hitdump
+#SBATCH --output=/sdf/group/neutrino/pgranger/larnd-sim-jax/logs/hitdump/job-%A_%a.out
+#SBATCH --ntasks=1 --cpus-per-task=2 --mem-per-cpu=32g
+#SBATCH --gpus-per-node=a100:1 --time=04:00:00
+#SBATCH --array=0-0
+#
+# Dump SIMULATED HIT LISTS (adc, tick, pixel) so the standard lifetime measurement can be redone
+# on reconstructed hits instead of truth segments.
+#
+# WHY: the truth-level study (S6k) recovers tau to -1.2% and is exactly scale-immune, but it
+# bypasses the entire front end. The real question is what the FEE does: the discrimination
+# threshold (5000 e-) preferentially kills SMALL hits, and small hits are the ones that drifted
+# FURTHEST and lost the most charge -- a selection that flattens the dQ/dx-vs-t slope and
+# therefore BIASES the lifetime upward. Electronics noise then adds an Eddington-style bias on
+# top: near threshold, upward noise fluctuations are selected in and downward ones are lost.
+#
+# HOW: the fitter already simulates and caches a target hit list per batch as
+#   {target_dir}/batch{i}_target.npz  (adcs, pixel_x, pixel_y, pixel_z, ticks, hit_prob, event)
+# generated from `target_params` on each batch's FIRST visit. Setting LARND_KEEP_TARGETS=1 stops
+# them being deleted at the end of the run. A plain `--fit_type chain` run visits every batch once
+# per epoch, so ITERATIONS=NB generates exactly one target per batch and stops -- a few minutes,
+# rather than the ~1h a scan would take.
+#
+# NOISE=on  -> readout noise simulated for the target (production default)
+# NOISE=off -> --no-noise-target, the control
+set -e
+NB=${HITNB:-60}
+LEN=${HITLEN:-400}
+NOISE=${NOISE:-on}
+NOISEFLAG=""
+TAG="noise"
+# NOTE argparse declares these with HYPHENS ("--no-noise-target", dest=no_noise_target); the
+# underscore spelling is silently rejected as an unrecognised argument.
+if [ "$NOISE" = "off" ]; then
+  NOISEFLAG="--no-noise-target"
+  TAG="nonoise"
+fi
+
+TGT=/sdf/data/neutrino/cyifan/diffsim_input/true_through_muon_edep_10cm_vol1cm.h5
+mkdir -p /sdf/group/neutrino/pgranger/larnd-sim-jax/logs/hitdump
+echo "=== hit dump: NOISE=${NOISE} NB=${NB} LEN=${LEN} ==="
+nvidia-smi --query-gpu=name --format=csv,noheader
+
+apptainer exec --nv -B /sdf,/fs,/lscratch larndsim-jax_main.sif /bin/bash -c "
+cd /sdf/group/neutrino/pgranger/larnd-sim-jax
+export PYTHONPATH=\$PWD/src:\$PWD:\$PYTHONPATH
+export JAX_COMPILATION_CACHE_DIR=/sdf/group/neutrino/pgranger/.jax_cache
+export LARND_KEEP_TARGETS=1
+python3 -m optimize.example_run \
+  --params optimize/scripts/param_list_nd_noshift.yaml \
+  --input_file_sim ${TGT} --input_file_tgt ${TGT} \
+  --fit_type chain --iterations ${NB} --max_nbatch ${NB} --max_batch_len ${LEN} \
+  --data_seed 1 --seed 0 ${NOISEFLAG} \
+  --lr 1e-6 --optimizer_fn Adam --lr_scheduler constant_schedule --lr_kw '{}' \
+  --max_clip_norm_val 100 --electron_sampling_resolution 0.01 --number_pix_neighbors 4 \
+  --signal_length 150 --mode lut --lut_file src/larndsim/detector_properties/response_44.npy \
+  --loss_fn llhd --probabilistic_sim --sim_seed_strategy different --non_deterministic \
+  --out_label hitdump_${TAG} --test_name hitdump --save_freq 1000000
+" 2>&1 | grep -vE "UserWarning|warnings.warn" | tail -40
+echo "=== targets kept in: target_hitdump_hitdump_${TAG}_* ==="
+ls -d target_hitdump* 2>/dev/null
+echo "=== done ==="

--- a/optimize/scripts/start_loss_profile.sh
+++ b/optimize/scripts/start_loss_profile.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+#SBATCH --partition=ampere
+#SBATCH --account=neutrino:cider-nu
+#SBATCH --job-name=lossprof
+#SBATCH --output=/sdf/group/neutrino/pgranger/larnd-sim-jax/logs/loss_profile/job-%A_%a.out
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem-per-cpu=32g
+#SBATCH --gpus-per-node=a100:1
+#SBATCH --time=20:00:00
+#SBATCH --array=0-2
+#
+# STUDY 1 — 1-D loss profile through the TRUE parameter point.
+#
+# THE QUESTION: lifetime moves monotonically further from truth the more the optimizer works
+# (ANNEAL SumLR 134.5 -> -2.01%, ANNEALLONG 136.0 -> -2.70%, SLOWANNEAL 239.4 -> -5.02%).
+# Either (a) the loss minimum IS at truth and annealing has not arrived, or (b) the minimum is
+# genuinely displaced and better optimization converges to a wrong answer. NO FIT CAN SEPARATE
+# THESE. This scan does, because it never runs an optimizer: it evaluates the loss on a grid.
+#
+# HOW: LikelihoodProfiler (--fit_type scan) walks each of the 5 calibration parameters across
+# its ranges.py [down, up] interval, holding the OTHER four at the values given by
+# --set_init_params. We set both the target (--scan_tgt_nom, which pins the target to
+# ranges[p]['nom']) and the init to those same nominal values, so every scan is a 1-D slice
+# through the TRUE point. If the per-parameter minimum sits at nominal, the objective is
+# unbiased for that parameter; if it is displaced, we have measured a real bias and its size.
+#
+# This is a 1-D SLICE, not a profile likelihood: the other parameters are held fixed rather than
+# re-minimised. That is the right first measurement (it isolates the objective from optimizer and
+# from parameter correlations), but a displaced minimum here must be re-checked with the other
+# parameters profiled before being called a bias.
+#
+# GEOMETRY sets the condition:
+#   GEOM=true   -> sim geometry = target geometry (the S2 condition: isolates the objective)
+#   GEOM=guess  -> sim geometry = straight-line guess (the S3 condition: adds geometry error)
+set -e
+SEED=${SLURM_ARRAY_TASK_ID:-0}
+STEPS=${PROFSTEPS:-21}
+NB=${PROFNBATCH:-30}
+LEN=${PROFLEN:-400}
+GEOM=${GEOM:-true}
+
+INPUT_FILE_TGT=/sdf/data/neutrino/cyifan/diffsim_input/true_through_muon_edep_10cm_vol1cm.h5
+LINEAR_GUESS=/sdf/group/neutrino/pgranger/lads-data/linear_guess_segments.h5
+# SIMFILE lets the quality-ladder files (optimize/scripts/make_quality_ladder.py) be scanned:
+# controlled degradations of the TRUE file along ONE axis (position RMS, or dE/dx spread),
+# so the scan measures how the loss-minimum location depends on that quality alone.
+if   [ -n "${SIMFILE:-}" ];  then INPUT_FILE_SIM=$SIMFILE
+elif [ "$GEOM" = "guess" ]; then INPUT_FILE_SIM=$LINEAR_GUESS
+else                              INPUT_FILE_SIM=$INPUT_FILE_TGT; fi
+
+# Scan centre = the nominal values that --scan_tgt_nom pins the target to (optimize/ranges.py).
+NOM="Ab 0.8 eField 0.5 tran_diff 8.8e-6 long_diff 4.0e-6 lifetime 2200"
+
+SIF_FILE=/sdf/group/neutrino/pgranger/larnd-sim-jax/larndsim-jax_main.sif
+mkdir -p /sdf/group/neutrino/pgranger/larnd-sim-jax/logs/loss_profile
+
+echo "=== Job started: $(date) ==="
+echo "=== STUDY1 loss profile: GEOM=${GEOM} SEED=${SEED} STEPS=${STEPS} NB=${NB} LEN=${LEN} ==="
+echo "=== sim=${INPUT_FILE_SIM} ==="
+echo "=== scan centre (also the target, via --scan_tgt_nom): ${NOM} ==="
+nvidia-smi --query-gpu=name,memory.total --format=csv,noheader
+
+apptainer exec --nv -B /sdf,/fs,/sdf/scratch,/lscratch ${SIF_FILE} /bin/bash -c "
+cd /sdf/group/neutrino/pgranger/larnd-sim-jax
+export PYTHONPATH=\$PWD/src:\$PWD:\$PYTHONPATH
+export JAX_COMPILATION_CACHE_DIR=/sdf/group/neutrino/pgranger/.jax_cache
+# SCANWINDOW>0 narrows every scan to nom*(1 +/- w) instead of the full ranges.py interval.
+# Unset/0 = previous behaviour exactly. Cost is steps x batches and does NOT depend on the span,
+# so a narrow window buys resolution for free.
+export LARND_SCAN_WINDOW=${SCANWINDOW:-0}
+echo \"[SCAN-ENV] window=\$LARND_SCAN_WINDOW steps=${STEPS} nbatch=${NB}\"
+python3 -m optimize.example_run \
+    --params optimize/scripts/param_list_nd_noshift.yaml \
+    --input_file_sim ${INPUT_FILE_SIM} \
+    --input_file_tgt ${INPUT_FILE_TGT} \
+    --fit_type scan \
+    --scan_tgt_nom \
+    --iterations ${STEPS} \
+    --max_nbatch ${NB} \
+    --max_batch_len ${LEN} \
+    --data_seed 1 \
+    --seed ${SEED} \
+    --set_init_params ${NOM} \
+    --lr 1e-1 --optimizer_fn Adam --lr_scheduler constant_schedule --lr_kw '{}' \
+    --max_clip_norm_val 100 \
+    --electron_sampling_resolution 0.01 \
+    --number_pix_neighbors 4 \
+    --signal_length 150 \
+    --mode lut \
+    --lut_file src/larndsim/detector_properties/response_44.npy \
+    --loss_fn llhd \
+    --probabilistic_sim \
+    --sim_seed_strategy different \
+    --non_deterministic \
+    --out_label prof_${GEOM}${PROFTAG:+_${PROFTAG}}_seed${SEED} \
+    --test_name loss_profile \
+    --save_freq 100000
+"
+echo "=== Job finished: $(date) ==="


### PR DESCRIPTION
## The bug

`_chain_active` and the `pos_residual` recorder gated on `total_iter % freq == 0`.

Under sequential batching, batch *b* is always visited at `total_iter ≡ b (mod nbatch)` — so that
condition is a **fixed function of the batch index**. With `freq > 1`, a fixed subset of batches
receives *every* update and the rest receive **none, ever**. Measured at `nbatch=100`:

| `chain_update_freq` | batches that never update |
|---|---|
| 2 | **50 / 100** |
| 4 | 75 / 100 |
| 5 | 80 / 100 |
| 10 | 90 / 100 |

Shuffling the batch order accidentally repairs it, which also makes shuffled and sequential runs
incomparable in principle.

## The fix

`_freq_gate(tag, batch_idx, freq)` — a per-batch visit counter.

- **`freq <= 1` returns immediately**, so the default path is unchanged and no existing run differs.
- At `freq=3`, every batch fires exactly 3 times in 9 epochs under **both** sequential and shuffled
  order, with identical counts.

`_pos_residual_freq` had the same defect and is fixed the same way.

## Also in this PR

Both additive, both about making scans and diagnostics readable.

**`LARND_SCAN_WINDOW`** narrows the likelihood-scan grid to `nom*(1 ± w)` instead of the full
`ranges.py` interval. Unset/0 = previous behaviour exactly. The full-range grid is much coarser than
the likelihood width — the lifetime step is 10.2% of truth against a 0.88% Fisher σ — so the
parabola vertex is an extrapolation and moves ~2.4 points between a 3- and a 5-point fit. Scan cost
is `steps × batches` and does not depend on the span, so the extra resolution is free.

**`pos_residual_batch`** records which batch each position residual belongs to. `pos_residual` is a
per-batch quantity and batches differ enormously (individual batches span 62–3051 µm around an
881 µm median), so a bare time series cannot be compared across any reordering.

**Scripts** (`optimize/scripts/`): quality-ladder and re-segmentation generators — controlled
degradations of the true segment file along one axis at a time — plus job drivers for the
likelihood-scan, hit-dump and batch-size-ceiling studies.

## Scope and risk

`optimize/fit_params.py` is **+45 / −2**. Defaults are unchanged throughout: `chain_update_freq` and
`pos_residual_freq` both default to 1, and `LARND_SCAN_WINDOW` defaults to off. The only behavioural
difference appears when a frequency knob is raised above 1 — which, before this PR, silently
corrupted the run.

This is the first of several extractions from a working tree where a number of features were
developed in parallel; the others (GN-on-calibration, GN-on-dE/dx, the dE/dx reparametrisation, the
minimum-length cut, truth-referenced dE/dx diagnostics) are independent and will follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMc19Km3iX9DSrSGRf7Zz2